### PR TITLE
test projects can use django_extensions

### DIFF
--- a/pwdtk/testproject/dj18/settings.py
+++ b/pwdtk/testproject/dj18/settings.py
@@ -39,7 +39,7 @@ AUTHENTICATION_BACKENDS = [
 # Application definition
 
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -47,7 +47,11 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'pwdtk',
-)
+]
+if os.environ.get('USE_DJANGO_EXTENSIONS', "no").lower()[:1] in "yt1":
+    INSTALLED_APPS += [
+        "django_extensions"
+        ]
 
 PASSWORD_DURATION_SECONDS = 180
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,4 @@
+django-extensions
+jsonfield
 pytest
 pytest-django


### PR DESCRIPTION
shall simplify interactive working with test projects like manage.py shell_plus, runserver_plus, etc.