### PR TITLE
try to fix pwd change issue if hasher different gto, dflt

### DIFF
--- a/pwdtk/helpers.py
+++ b/pwdtk/helpers.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-
+import inspect
 import datetime
 import dateutil
 
@@ -58,3 +58,17 @@ def seconds_to_iso8601(seconds):
     seconds = seconds.rstrip('0')
     time += '{}S'.format(seconds)
     return u'P' + date + time
+
+
+def recursion_depth():
+    """return recursion depth. 0 if no recursion"""
+    # taken from https://github.com/looking-for-a-job/recursion-detect.py
+    counter = 0
+    frames = inspect.getouterframes(inspect.currentframe())[1:]
+    top_frame = inspect.getframeinfo(frames[0][0])
+    for frame, _, _, _, _, _ in frames[1:]:
+        (path, line_number, func_name, lines, index) = inspect.getframeinfo(
+            frame)
+        if path == top_frame[0] and func_name == top_frame[2]:
+            counter += 1
+    return counter

--- a/pwdtk/testproject/dj18/settings.py
+++ b/pwdtk/testproject/dj18/settings.py
@@ -135,3 +135,8 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'cstatic18')
 TEST_RUNNER = 'pwdtk.testproject.pytest_runner.PytestTestRunner'
 
 from pwdtk.testproject.logcfg import LOGGING  # noqa: F401
+
+# Just for debugging
+# PASSWORD_HASHERS = [
+#     'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
+#     ]

--- a/pwdtk/tests/fixtures.py
+++ b/pwdtk/tests/fixtures.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import logging
+
+import pytest
+
+from django.contrib.auth import get_user_model
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def two_users():
+    """ create two users with two passwords """
+    User = get_user_model()
+    users = []
+    for ctr in range(2):
+        username = 'user%d' % ctr
+        passwd = 'pwd%d' % ctr
+        usr = User(username=username)
+        usr.save()
+        usr.set_password(passwd)
+        usr.is_staff = True
+        usr.save()
+        logger.debug("create user %r %r", username, passwd)
+        users.append((username, passwd))
+
+    return users

--- a/pwdtk/tests/test_login.py
+++ b/pwdtk/tests/test_login.py
@@ -5,41 +5,24 @@ import datetime
 import logging
 
 import dateutil.parser
+import django
 import pytest
 
+
 from builtins import range
-import django
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.http.response import HttpResponseRedirect
 from django.test import Client
 
 from pwdtk.auth_backends import MHPwdPolicyBackend
+from pwdtk.tests.fixtures import two_users  # noqa: F401
 
 
 logger = logging.getLogger(__name__)
 
 AUTH_URL = settings.PWDTK_TEST_ADMIN_URL
 UserData = MHPwdPolicyBackend.get_user_data_cls()
-
-
-@pytest.fixture
-def two_users():
-    """ create two users with two passwords """
-    User = get_user_model()
-    users = []
-    for ctr in range(2):
-        username = 'user%d' % ctr
-        passwd = 'pwd%d' % ctr
-        usr = User(username=username)
-        usr.save()
-        usr.set_password(passwd)
-        usr.is_staff = True
-        usr.save()
-        logger.debug("create user %r %r", username, passwd)
-        users.append((username, passwd))
-
-    return users
 
 
 def do_login(client, data, use_good_password=True, shall_pass=None):
@@ -142,7 +125,7 @@ def set_password_age(username, age, offset=0):
 
 
 @pytest.mark.django_db
-def test_login_no_form(two_users):
+def test_login_no_form(two_users):  # noqa: F811
     """ client login without the login url """
     browser = "Mozilla/5.0"
     client = Client(browser=browser)
@@ -162,7 +145,7 @@ def test_login_no_form(two_users):
 
 
 @pytest.mark.django_db
-def test_login(two_users):
+def test_login(two_users):  # noqa: F811
     """ login via the login url """
     browser = "Mozilla/5.0"
     client = Client(browser=browser)
@@ -230,7 +213,7 @@ def test_login(two_users):
 
 
 @pytest.mark.django_db
-def test_pwd_expire(two_users):
+def test_pwd_expire(two_users):  # noqa: F811
     """ test whether a password renewal is demanded if a password
         has not been changed for a given time.
     """

--- a/pwdtk/tests/test_pwd_hash.py
+++ b/pwdtk/tests/test_pwd_hash.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+from __future__ import print_function
+
+import importlib
+
+import pytest
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from pwdtk.tests.fixtures import two_users  # noqa: F401
+
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+def test_pwd_nodflt_hash(two_users):  # noqa: F811
+    """ can pwdtk handle a non default pwd hash """
+    username, passwd = two_users[0]
+    user = User.objects.get(username=username)
+    print("user %s with %r" % (user, passwd))
+    hashers = settings.PASSWORD_HASHERS
+    print("hashers:\n%s", "\n".join(str(hasher) for hasher in hashers))
+    salt = ""
+    if "django.contrib.auth.hashers.UnsaltedMD5PasswordHasher" in hashers:
+        hasher_cls_name = ("django.contrib.auth.hashers"
+                           ".UnsaltedMD5PasswordHasher")
+    else:
+        hasher_cls_name = hashers[-1]
+        if hasher_cls_name.endswith("CryptPasswordHasher"):
+            salt = "ab"
+
+    assert hasher_cls_name != hashers[0]
+    hasher_modname, hasher_name = hasher_cls_name.rsplit(".", 1)
+    hasher_mod = importlib.import_module(hasher_modname)
+    print("try to import %s:%s" % (hasher_modname, hasher_name))
+    hasher = getattr(hasher_mod, hasher_name)()
+    print("hasher = ", hasher)
+    passwd_hash = hasher.encode(passwd, salt)
+    print("passwd: %s -> %r" % (passwd, passwd_hash))
+
+    user.password = passwd_hash
+    user.save()
+
+    user = User.objects.get(username=username)
+    assert user.check_password(passwd)

--- a/pwdtk/testviews.py
+++ b/pwdtk/testviews.py
@@ -37,6 +37,7 @@ Welcome to the protected space.<br/>
 You are {{ username }}
 This space requires to be authenticated<br/>
 <a href="/">Top</a><br/>
+<a href="/admin/password_change/">Change password</a><br/>
 <a href="/logout?next=/protected">Logout</a><br/>
 """
 


### PR DESCRIPTION
This solution is quite ugly and should be repalced with a better one.

A new test has been added to reproduce the problem prior to fixing it (TDD)

It detects, when the set_password hook is called recursively.
So far we assume this happens only if a user logs in with his password
and the hashing algorithm is not the default one.