### PR TITLE
limit minibelt reqs + bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Changelog](https://github.com/mhcomm/django-pwdtk/releases)
 
+## [v0.2.5](https://github.com/mhcomm/django-pwdtk/compare/0.2.4...v0.2.5)
+* fix requirements in order to remain py2 compatible (limit minibelt to < 0.2.0)
 ## [v0.2.4](https://github.com/mhcomm/django-pwdtk/compare/0.2.3...v0.2.4)
 * fix bug #13 (potential issues with django introspection due to monkey patches
 ## [v0.2.3](https://github.com/mhcomm/django-pwdtk/compare/0.2.2...v0.2.3)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,3 @@
 future
-minibelt
+minibelt<0.2.0
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ It spans a rather wide range of python and django versions and supports:
 
 setup(
     name="django-pwdtk",
-    version="0.2.4",
+    version="0.2.5",
     description="package to tune django password authentification",
     #long_description=long_description,
     #long_description_content_type="text/x-rst",


### PR DESCRIPTION
minibelt limited to <0.2.0 for py2 compatibility