### PR TITLE
shall allow to completely disable pwdtk

### DIFF
--- a/pwdtk/apps.py
+++ b/pwdtk/apps.py
@@ -21,9 +21,10 @@ class PwdTkConfig(AppConfig):
             The required hooks depend on the django version.
 
         """
-        # TODO: add hooks only if pwdtk feature needing the hook has been
-        # enabled
         logger.debug("PWDTK READY")
+        if not settings.PWDTK_ENABLED:
+            logger.debug("PWDTK DISABLED")
+            return
         if django.VERSION < (1, 11):
             # Connect Signals
             import pwdtk.sig_receivers  # noqa: F401

--- a/pwdtk/auth_backends.py
+++ b/pwdtk/auth_backends.py
@@ -25,6 +25,7 @@ from pwdtk.helpers import seconds_to_iso8601
 logger = logging.getLogger(__name__)
 # logger.debug("######## Imp backend2")  # for debugging dj 1.8 -> 1.11
 
+PWDTK_ENABLED = settings.PWDTK_ENABLED
 PWDTK_USER_FAILURE_LIMIT = settings.PWDTK_USER_FAILURE_LIMIT
 PWDTK_IP_FAILURE_LIMIT = settings.PWDTK_IP_FAILURE_LIMIT
 PWDTK_LOCKOUT_TIME = settings.PWDTK_LOCKOUT_TIME
@@ -141,6 +142,9 @@ class MHPwdPolicyBackend(object):
 
     def authenticate(self, request=None, username=None, password=None,
                      **kwargs):
+        if not PWDTK_ENABLED:
+            return None
+
         logger.debug(
             "############## MHAUTH: %s %s %s %s",
             repr(request), repr(username), repr(password), repr(kwargs))

--- a/pwdtk/middlewares.py
+++ b/pwdtk/middlewares.py
@@ -2,6 +2,7 @@ import json
 import logging
 
 from django.conf import settings
+from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils.deprecation import MiddlewareMixin
@@ -15,6 +16,12 @@ PWDTK_PASSWD_CHANGE_VIEW = settings.PWDTK_PASSWD_CHANGE_VIEW
 
 
 class PwdtkMiddleware(MiddlewareMixin):
+    def __init__(self, get_response):
+        if not settings.PWDTK_ENABLED:
+            logger.debug("PWDTK middleware is disabled")
+            raise MiddlewareNotUsed("pwdtk is disabled")
+        super(PwdtkMiddleware, self).__init__(get_response)
+
     def process_request(self, request):
         logger.debug("PWDTK Proc Req %s %s", request.user, repr(request))
         request.pwdtk_fail_user = None

--- a/pwdtk/settings.py
+++ b/pwdtk/settings.py
@@ -21,8 +21,13 @@ def add_middlewares(
 
     middlewares[idx:idx] = to_insert
 
+
 # PWDTK Common settings for login / logout views
 # ----------------------------------------------------------
+
+# Allow to completely enable / disable pwdtk
+# This should disable all hooks / middlewares and auth backends
+PWDTK_ENABLED = True
 
 
 # Model to be used for storing PWDTK related info


### PR DESCRIPTION
pwdtk can be disabled even if it has been added to installed apps
and even if auth backends were added in django settings

- middlewares will be disabled at startup
- App.ready will do nothing
- auth backends will be called but do nothing