### PR TITLE
new release to force upd for pip install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Changelog](https://github.com/mhcomm/django-pwdtk/releases)
 
+## [v0.2.7](https://github.com/mhcomm/django-pwdtk/compare/v0.2.6...v0.2.7)
+* same as 0.2.7, but rebuilt somehow a bad migration file slipped into the release
 ## [v0.2.6](https://github.com/mhcomm/django-pwdtk/compare/v0.2.5...v0.2.6)
 * add migrations to force uniqueness on PwdData (PwdData.username should be unique)
 ## [v0.2.5](https://github.com/mhcomm/django-pwdtk/compare/v0.2.4...v0.2.5)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ It spans a rather wide range of python and django versions and supports:
 
 setup(
     name="django-pwdtk",
-    version="0.2.6",
+    version="0.2.7",
     description="package to tune django password authentification",
     #long_description=long_description,
     #long_description_content_type="text/x-rst",


### PR DESCRIPTION
one bad rls was created. 

This version is just there to force a new release without the accidentally slipped in migration