### PR TITLE
Fix compatibility with py38 on dj4 setup

### DIFF
--- a/pwdtk/models.py
+++ b/pwdtk/models.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import sys
+
 import django
 from django.conf import settings
 from django.contrib.auth.password_validation import get_default_password_validators
@@ -88,7 +90,7 @@ class PwdData(models.Model):
         if timezone.is_aware(self.fail_time):
             return self.fail_time
         else:
-            if django.VERSION < (4, 0):
+            if django.VERSION < (4, 0) or sys.version_info < (3, 9):
                 import pytz
                 return pytz.timezone(
                     PwdtkSettings.TIME_ZONE).localize(self.fail_time)

--- a/pwdtk/tests/test_timezone.py
+++ b/pwdtk/tests/test_timezone.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+# ############################################################################
+# Copyright  : (C) 2025 by MHComm. All rights reserved
+#
+# Name       : pwdtk.tests.test_timezone
+"""
+  Summary    : Test timezone related functions
+
+__author__ = "Jonathan Lajus"
+__email__ = "info@mhcomm.fr"
+"""
+# #############################################################################
+
+import datetime
+
+from pwdtk.models import PwdData
+
+def test_aware_fail_time():
+    data = PwdData()
+    data.fail_time = datetime.datetime(2025, 6, 1, 0, 0, 0, tzinfo=None)
+    assert data.aware_fail_time.tzinfo is not None


### PR DESCRIPTION
ModuleNotFoundError: No module named 'zoneinfo' on py3.8 (zoneinfo is only available on py3.9)