### PR TITLE
Remove usage of PwdtkSettings in django init

### DIFF
--- a/pwdtk/apps.py
+++ b/pwdtk/apps.py
@@ -4,8 +4,7 @@ from django.apps import AppConfig
 
 logger = logging.getLogger(__name__)
 
-
-logger.debug("imp pwdtk APPS")  # added trace for dbg of dj 1.8 -> dj 1.11
+logger.debug("imp pwdtk APPS")
 
 
 class PwdTkConfig(AppConfig):

--- a/pwdtk/apps.py
+++ b/pwdtk/apps.py
@@ -17,6 +17,3 @@ class PwdTkConfig(AppConfig):
             The required hooks depend on the django version.
         """
         logger.debug("PWDTK READY")
-        if not PwdtkSettings.PWDTK_ENABLED:
-            logger.debug("PWDTK DISABLED")
-            return

--- a/pwdtk/apps.py
+++ b/pwdtk/apps.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.apps import AppConfig
-from pwdtk.helpers import PwdtkSettings
 
 logger = logging.getLogger(__name__)
 

--- a/pwdtk/middlewares.py
+++ b/pwdtk/middlewares.py
@@ -1,8 +1,6 @@
 import json
 import logging
 
-
-from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponse
 
 try:
@@ -21,17 +19,6 @@ logger = logging.getLogger(__name__)
 
 
 class PwdtkMiddleware(MiddlewareMixin):
-
-    def __init__(self, get_response=None):
-
-        if not PwdtkSettings.PWDTK_ENABLED:
-            logger.debug("PWDTK middleware is disabled")
-            raise MiddlewareNotUsed("pwdtk is disabled")
-        if get_response:
-            super(PwdtkMiddleware, self).__init__(
-                get_response=get_response)
-        else:
-            super(PwdtkMiddleware, self).__init__()
 
     def process_request(self, request):
         if hasattr(PwdtkSettings, "reset_cache"):

--- a/pwdtk/middlewares.py
+++ b/pwdtk/middlewares.py
@@ -9,11 +9,9 @@ except: # noqa E722
     class MiddlewareMixin(object):
         pass
 
-
 from pwdtk.auth_backends import PwdtkForceRenewException
 from pwdtk.auth_backends import PwdtkLockedException
 from pwdtk.helpers import PwdtkSettings
-
 
 logger = logging.getLogger(__name__)
 

--- a/pwdtk/middlewares.py
+++ b/pwdtk/middlewares.py
@@ -19,10 +19,16 @@ logger = logging.getLogger(__name__)
 class PwdtkMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
+        # Will still be called even if PwdtkSettings.PWDTK_ENABLED is False.
+        # Only use safe code here or add a conditional on
+        # PwdtkSettings.PWDTK_ENABLED when necessary to keep the logic sound.
         if hasattr(PwdtkSettings, "reset_cache"):
             PwdtkSettings.reset_cache()
 
     def process_exception(self, request, exception):
+        # Will still be called even if PwdtkSettings.PWDTK_ENABLED is False.
+        # Only use safe code here or add a conditional on
+        # PwdtkSettings.PWDTK_ENABLED when necessary to keep the logic sound.
 
         if isinstance(exception, PwdtkLockedException):
             context = exception.pwdtk_data.get_lockout_context()


### PR DESCRIPTION
If we do not use a true setting but a custom setting class that is not really something static (DB lookup for example), this breaks django-async, django-tenants, etc.

As having an additional "logger.debug("PWDTK DISABLED")" is not really a core feature, best to just ditch it.